### PR TITLE
Deprecate size prop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-star-picker",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-star-picker",
-      "version": "4.2.0",
+      "version": "4.2.1",
       "license": "MIT",
       "devDependencies": {
         "@babel/cli": "^7.18.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-star-picker",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "description": "A star-rating component made with React",
   "type": "module",
   "exports": {

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,7 +18,7 @@ export type SharedProps = {
   halfStars: boolean;
   /** whether the input is disabled */
   disabled: boolean;
-  /** the size of the stars in px (used for font-size, button widths) */
+  /** the size of the stars in px (used for font-size, button widths). @deprecated To control the size of the stars, set the font-size property on the element with the StarPicker class via CSS instead. */
   size: number;
 };
 


### PR DESCRIPTION
Deprecate size prop. Star size to be controlled via CSS instead.