### PR TITLE
no source maps

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -26,7 +26,7 @@ export default [
         dir: "lib/esm",
         format: 'esm',
         exports: 'named',
-        sourcemap: true,
+        sourcemap: false,
         globals,
         banner: `'use client';`,
         // preserveModules: true,


### PR DESCRIPTION
Stop producing source maps to minimize build size by 70%.